### PR TITLE
Add development config and use env bucket

### DIFF
--- a/config/environment.ts
+++ b/config/environment.ts
@@ -27,7 +27,24 @@ const environments: Record<string, Environment> = {
       accessKeyId: process.env.TEST_R2_ACCESS_KEY_ID!,
       secretAccessKey: process.env.TEST_R2_SECRET_ACCESS_KEY!,
       publicUrl: process.env.TEST_R2_PUBLIC_URL!,
-      bucket: 'piattaforma-whls-test'
+      bucket: process.env.R2_BUCKET!
+    },
+    jwt: {
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '24h'
+    }
+  },
+  development: {
+    database: {
+      url: process.env.TEST_DATABASE_URL!,
+      ssl: false
+    },
+    r2: {
+      accountId: process.env.TEST_R2_ACCOUNT_ID!,
+      accessKeyId: process.env.TEST_R2_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.TEST_R2_SECRET_ACCESS_KEY!,
+      publicUrl: process.env.TEST_R2_PUBLIC_URL!,
+      bucket: process.env.R2_BUCKET!
     },
     jwt: {
       secret: process.env.JWT_SECRET!,
@@ -44,7 +61,7 @@ const environments: Record<string, Environment> = {
       accessKeyId: process.env.PROD_R2_ACCESS_KEY_ID!,
       secretAccessKey: process.env.PROD_R2_SECRET_ACCESS_KEY!,
       publicUrl: process.env.PROD_R2_PUBLIC_URL!,
-      bucket: 'piattaforma-whls-prod'
+      bucket: process.env.R2_BUCKET!
     },
     jwt: {
       secret: process.env.JWT_SECRET!,
@@ -53,4 +70,5 @@ const environments: Record<string, Environment> = {
   }
 }
 
-export const env = environments[process.env.NODE_ENV || 'development'] 
+const currentEnv = process.env.NODE_ENV || 'development'
+export const env = environments[currentEnv] ?? environments.development;


### PR DESCRIPTION
## Summary
- add development config identical to test
- fall back to development env if `NODE_ENV` is unknown
- read bucket name from `R2_BUCKET` for all environments

## Testing
- `npm test` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844571a10488325b5e8639888c16c4d