### PR TITLE
Fix Next.js route types

### DIFF
--- a/app/api/admin/cataloghi/[id]/files/[filesid]/route.ts
+++ b/app/api/admin/cataloghi/[id]/files/[filesid]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 
 interface FileUpdateData {
@@ -8,7 +8,7 @@ interface FileUpdateData {
 }
 
 export async function PATCH(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { id: string; filesid: string } }
 ) {
   try {
@@ -87,7 +87,7 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { id: string; filesid: string } }
 ) {
   try {


### PR DESCRIPTION
## Summary
- use `NextRequest` for admin catalog file PATCH and DELETE handlers

## Testing
- `npm run build:prod` *(fails: Bus error)*
- `npm test` *(fails: Invalid project directory)*

------
https://chatgpt.com/codex/tasks/task_e_6844564473b4832596fbb7670e6016e7