### PR TITLE
Fix comment translation

### DIFF
--- a/components/ui/address-autocomplete.tsx
+++ b/components/ui/address-autocomplete.tsx
@@ -184,7 +184,7 @@ export function AddressAutocomplete({
   }
 
   useEffect(() => {
-    // Aggiorna il parent con i valori correnti degli input quando cambiano
+    // Update parent component when manual address fields are filled
     if (manualAddress.street && manualAddress.city && manualAddress.postal_code) {
       onAddressSelect({
         street_address: manualAddress.street,


### PR DESCRIPTION
## Summary
- translate Italian comment in address autocomplete to English

## Testing
- `npm run test` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844572c7b54832593911dabd6078b51