### PR TITLE
Implement server logout call and cookie cleanup

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -16,6 +16,8 @@ export async function POST() {
   response.cookies.set('session', '', cookieOptions)
   response.cookies.set('user_role', '', cookieOptions)
   response.cookies.set('client_id', '', cookieOptions)
+  response.cookies.set('user_name', '', cookieOptions)
+  response.cookies.set('company_name', '', cookieOptions)
 
   return response
 } 

--- a/components/auth/logout-button.tsx
+++ b/components/auth/logout-button.tsx
@@ -36,9 +36,15 @@ export function LogoutButton() {
     try {
       // Pulisce tutti i dati del browser
       clearBrowserData()
-      
+
+      // Comunica al server di invalidare la sessione
+      const res = await fetch('/api/auth/logout', { method: 'POST' })
+      if (!res.ok) {
+        console.warn('Server logout failed')
+      }
+
       // Effettua il logout
-      await signOut({ 
+      await signOut({
         redirect: true,
         callbackUrl: '/login'
       })


### PR DESCRIPTION
## Summary
- clear `user_name` and `company_name` cookies on logout
- request `/api/auth/logout` from the logout button before calling `signOut`

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445f2d3f0c8325a243b0f116632c15