### PR TITLE
Use env vars for DB configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_USER=postgres
+DB_NAME=piattoforma
+DB_PASSWORD=yourpassword
+DB_PORT=5432

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ pnpm dev
 bun dev
 ```
 
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and provide your database
+connection details:
+
+```bash
+cp .env.example .env
+```
+
+The following variables are required:
+
+- `DB_HOST` - database host
+- `DB_USER` - database username
+- `DB_NAME` - database name
+- `DB_PASSWORD` - database password
+- `DB_PORT` - database port
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,11 +5,11 @@ export const runtime = 'nodejs';
 
 // Pool per connessioni dirette
 export const db = new Pool({
-  user: 'postgres',
-  host: 'localhost',
-  database: 'piattoforma',
-  password: '',
-  port: parseInt('5432'),
+  user: process.env.DB_USER || 'postgres',
+  host: process.env.DB_HOST || 'localhost',
+  database: process.env.DB_NAME || 'piattoforma',
+  password: process.env.DB_PASSWORD || '',
+  port: parseInt(process.env.DB_PORT || '5432', 10),
 });
 
 // SQL helper per query parametrizzate


### PR DESCRIPTION
## Summary
- use environment variables in `lib/db.ts` instead of hardcoded values
- document database environment variables in `README.md`
- provide `.env.example`
- allow tracking `.env.example` in `.gitignore`

## Testing
- `npm test` *(fails: `tsx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684464126660832582a11bbc344920c5