### PR TITLE
Fix socket server retrieval in notifications API

### DIFF
--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -223,7 +223,7 @@ export async function POST(request: Request) {
       }
       
       // @ts-ignore - Next.js types are not up to date
-      const server = (req as any).socket?.server as ServerWithIO
+      const server = (request as any).socket?.server as ServerWithIO
       const io = getIO(server)
       
       if (io) {


### PR DESCRIPTION
## Summary
- fix server retrieval when posting notifications

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446232a03c832581cd193c8ca9e962