### PR TITLE
Fix websocket URL protocol

### DIFF
--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -123,7 +123,7 @@ export function useNotifications() {
     
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const host = window.location.host
-    const socketUrl = `${window.location.protocol}//${host}`
+    const socketUrl = protocol + '//' + host
 
     console.log('🔌 Connessione socket a:', socketUrl)
     


### PR DESCRIPTION
## Summary
- construct `socketUrl` using the calculated `protocol` in `use-notifications`

## Testing
- `npm test` *(fails: database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684462348aa8832584a5108a8ff301d2