### PR TITLE
Fix pass.js secret source

### DIFF
--- a/pass.js
+++ b/pass.js
@@ -1,22 +1,20 @@
 #!/usr/bin/env node
 
-// Carica le variabili d'ambien
-
 const bcrypt = require('bcrypt');
-const secret = "ciaobellomio";
+
+const secret = process.argv[2] || process.env.NEXTAUTH_SECRET;
+
+if (!secret) {
+  console.error('Errore: nessun segreto fornito. Imposta NEXTAUTH_SECRET o passa il valore come argomento.');
+  process.exit(1);
+}
+
 (async () => {
   try {
-    const secret = "ciaobellomio";
-    if (!secret) {
-      console.error('Errore: la variabile NEXTAUTH_SECRET non è impostata in .env');
-      process.exit(1);
-    }
-
-    // Genera l'hash con bcrypt (saltRounds = 10)
     const hash = await bcrypt.hash(secret, 10);
     console.log(hash);
   } catch (err) {
-    console.error('Errore durante lhashing:', err);
+    console.error('Errore durante l\'hashing:', err);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
## Summary
- read secret from a CLI argument or `process.env.NEXTAUTH_SECRET`
- fail fast if no secret is provided

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_684464c883408325b95ce03f063d5010